### PR TITLE
카드 컴포넌트 제목을 안 받아오는 오류 고침

### DIFF
--- a/app/pages/CardContent.tsx
+++ b/app/pages/CardContent.tsx
@@ -34,7 +34,7 @@ function CardContent() {
                 <>
                     <S.Header>
                         <S.diseaseName>{H[0].Disease}</S.diseaseName>
-                        <S.CardTitle>만약 머리가 깨질 듯이 아프다면?</S.CardTitle>
+                        <S.CardTitle>{H[0].Title}</S.CardTitle>
 
                         <S.TagBox>
                             <S.diseaseTag>{`#${H[0].Tag}`}</S.diseaseTag>


### PR DESCRIPTION
변수가 아닌 일반 글자가 적용되어 있었음