### PR TITLE
Nav바 css 오류

### DIFF
--- a/app/styles/Nav.ts
+++ b/app/styles/Nav.ts
@@ -126,6 +126,7 @@ export const DangerousHap = styled.div.withConfig({
   text-align: center;
   gap: 25px;
   position: absolute;
+  z-index: 1010;
 `;
 
 export const Dangerous = styled.img`
@@ -184,12 +185,13 @@ export const AdminText = styled.span`
   font-weight: 700;
   right: 960px;
   position: absolute;
+  z-index: 900;
 `
 
 export const NavContainer = styled.div`
   width: 100%;
   height: 88px;
-  z-index: 2000;
+  z-index: 1000;
 
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -200,6 +202,6 @@ export const NavContainer = styled.div`
   justify-content: space-between;
   align-items: center;
 
-  position: absolute;
+  position: relative;
   top: 0px;
 `

--- a/app/styles/VisitModal.ts
+++ b/app/styles/VisitModal.ts
@@ -25,7 +25,7 @@ export const background = styled.div`
     display: flex;
     justify-content: center;
     align-items: center;
-    z-index: 1000;
+    z-index: 2000;
 `;
 
 export const modaltitle = styled.span`


### PR DESCRIPTION
Nav바의 내부 컴포넌트들이 모달창이 열렸을 때 제공되는 흑색 배경화면 보다 앞부분에 표시가 되는 z-index 충돌 오류
->
modal창의 z-index값을 증가시키고, 반대로 Nav_container의 z-index 값을 감소시켜 해결