### PR TITLE
bugfix: 문진표 페이지의 메인보드, 서브보드의 데이터 표시 현황에 관련된 버그 수정

### DIFF
--- a/app/components/Calendar.tsx
+++ b/app/components/Calendar.tsx
@@ -1,67 +1,23 @@
-import { useState, useEffect } from "react";
-import axios from "axios";
-import { 
-  format, addMonths, subMonths, startOfMonth, endOfMonth, 
-  addDays, isToday, isSameDay, getDay, subDays 
-} from "date-fns";
+import { useState, useEffect } from 'react';
+import { useCalendarStore } from '@/store/useCalendarStore';
+import { format, addMonths, subMonths, startOfMonth, endOfMonth, addDays, isToday, isSameDay, getDay, subDays } from 'date-fns';
 
 const Calendar = () => {
   const [currentMonth, setCurrentMonth] = useState(new Date());
-  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
-  const [data, setData] = useState<any>(null);
+  const { selectedDate, setSelectedDate, fetchDailyData } = useCalendarStore();
 
   const prevMonth = () => setCurrentMonth(subMonths(currentMonth, 1));
   const nextMonth = () => setCurrentMonth(addMonths(currentMonth, 1));
 
-  const fetchDateData = async (date: Date) => {
-    try {
-      const yearMonthDayParam = format(date, "yyyy.MM.dd");
-      const response = await axios.get(`${process.env.NEXT_PUBLIC_REACT_APP_BASE_URL}/questionnaire/date?yearMonthDay=${yearMonthDayParam}`, {
-        headers: {
-          'ngrok-skip-browser-warning': '69420',
-        },
-      }
-    );
-      console.log("API 응답:", response.data);
-      setData(response.data)
-    }
-    
-    catch (error) {
-      console.error("API 요청 오류:", error);
-    }
-  };
-
-  const fetchInitialData = async () => {
-    try {
-      const response = await axios.get(
-        `${process.env.NEXT_PUBLIC_REACT_APP_BASE_URL}/questionnaire/date`,
-        {
-          headers: {
-            "ngrok-skip-browser-warning": "true",
-          },
-        }
-      );
-      console.log("초기 API 응답:", response.data);
-      setData(response.data);
-    } catch (error) {
-      console.error("초기 API 요청 오류:", error);
-    }
-  };
-  
-  useEffect(() => {
-    fetchInitialData();
-  }, []);  
-
   const handleDateClick = (date: Date) => {
     setSelectedDate(date);
-    fetchDateData(date);
+    fetchDailyData(date);
   };
 
   const renderDays = () => {
     const startDate = startOfMonth(currentMonth);
     const endDate = endOfMonth(currentMonth);
     const startDayIndex = getDay(startDate);
-
     let days = [];
 
     const prevMonthEndDate = subDays(startDate, startDayIndex);
@@ -81,8 +37,7 @@ const Calendar = () => {
       const isCurrentDay = isToday(currentDay);
       const dayOfWeek = getDay(currentDay);
 
-      const textColor =
-        dayOfWeek === 0 ? "text-red-500" : dayOfWeek === 6 ? "text-blue-500" : "text-gray-600";
+      const textColor = dayOfWeek === 0 ? "text-red-500" : dayOfWeek === 6 ? "text-blue-500" : "text-gray-600";
 
       days.push(
         <div key={day.toString()} className={`w-12 h-10 flex items-center justify-center ${textColor}`}>
@@ -104,6 +59,11 @@ const Calendar = () => {
     return days;
   };
 
+  useEffect(() => {
+    const { initialize } = useCalendarStore.getState();
+    initialize();
+  }, []);
+
   return (
     <div className="w-[450px] h-[330px] absolute left-[1190px] top-[200px] bg-white rounded-[10px] flex">
       <div className="w-full h-96 p-4 bg-white rounded-lg shadow-md">
@@ -117,9 +77,7 @@ const Calendar = () => {
           {["일", "월", "화", "수", "목", "금", "토"].map((day, index) => (
             <div
               key={index}
-              className={`w-12 flex justify-center font-medium ${
-                day === "일" ? "text-red-500" : day === "토" ? "text-blue-500" : "text-gray-600"
-              }`}
+              className={`w-12 flex justify-center font-medium ${day === "일" ? "text-red-500" : day === "토" ? "text-blue-500" : "text-gray-600"}`}
             >
               {day}
             </div>

--- a/app/components/Mainsheet.tsx
+++ b/app/components/Mainsheet.tsx
@@ -1,87 +1,32 @@
 'use client';
-import { useState, useEffect } from "react";
-import axios from "axios";
-import * as S from "../styles/Mainsheet";
 
-interface SheetData {
-  serialNumber: number;
-  userName: string;
-  schoolNumber: string;
-  gender: string;
-  division: string;
-  disease: string;
-  treatment: string;
-  quantity: number;
-  medication1: string;
-  quantity1: number;
-  medication2: string;
-  quantity2: number;
-  notes: string;
-}
+import { useCalendarStore } from '@/store/useCalendarStore';
+import { useEffect } from 'react';
+import * as S from '../styles/Mainsheet';
 
-interface SheetResponse {
-  questionnaires: SheetData[];
-  groupedStatistics?: any; // 필요에 따라 타입 구체화 가능
-}
+const divisionMap: { [key: string]: string } = {
+  RESPIRATORY_SYSTEM: '호흡기계',
+  DIGESTIVE_SYSTEM: '소화기계',
+  CIRCULATORY_SYSTEM: '순환기계',
+  NERVOUS_SYSTEM: '정신신경계',
+  MUSCULOSKELETAL_SYSTEM: '근골격계',
+  INTEGUMENTARY_SYSTEM: '피부피하계',
+  UROGENITAL_SYSTEM: '비뇨생식기계',
+  DENTAL_SYSTEM: '구강치아계',
+  OTORHINOLARYNGOLOGY: '이비인후과계',
+  OPHTHALMOLOGY_SYSTEM: '안과계',
+  INFECTIOUS_DISEASE: '감염병',
+  MENTAL_COUNSELING: '상담',
+  OTHER: '기타',
+};
 
-function Td(props: { onEnter: () => void; onSpace: () => void }) {
-  function handleKey(event: React.KeyboardEvent<HTMLInputElement>) {
-    if (event.key === "Enter") {
-      props.onEnter(); // Enter 입력 시 행 추가
-    } else if (event.key === "Backspace") { 
-      props.onSpace(); // Space 입력 시 행 삭제
-    }
-  }
-return(
-<>
-<S.Td><S.Count ></S.Count></S.Td>
-</>
-
-)
-}
+const genderMap: { [key: string]: string } = {
+  MAN: '남성',
+  WOMAN: '여성',
+};
 
 function MainSheet() {
-  const [data, setData] = useState<SheetResponse | null>(null);
-  const divisionMap: { [key: string]: string } = {
-    RESPIRATORY_SYSTEM: "호흡기계",
-    DIGESTIVE_SYSTEM: "소화기계",
-    CIRCULATORY_SYSTEM: "순환기계",
-    NERVOUS_SYSTEM: "정신신경계",
-    MUSCULOSKELETAL_SYSTEM: "근골격계",
-    INTEGUMENTARY_SYSTEM: "피부피하계",
-    UROGENITAL_SYSTEM: "비뇨생식기계",
-    DENTAL_SYSTEM: "구강치아계",
-    OTORHINOLARYNGOLOGY: "이비인후과계",
-    OPHTHALMOLOGY_SYSTEM: "안과계",
-    INFECTIOUS_DISEASE: "감염병",
-    MENTAL_COUNSELING: "상담",
-    OTHER: "기타",
-  };
-  
-  const genderMap: { [key: string]: string } = {
-    MAN: "남성",
-    WOMAN: "여성",
-  };
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const res = await axios.get<SheetResponse>(
-          `${process.env.NEXT_PUBLIC_REACT_APP_BASE_URL}/questionnaire/date`, {
-            headers: {
-              'ngrok-skip-browser-warning': '69420',
-            }
-          }
-        );
-        console.log("초기 API 응답:", res.data);
-        setData(res.data);
-      } catch (err) {
-        console.error("데이터 불러오기 오류:", err);
-      }
-    };
-  
-    fetchData();
-  }, []);
+  const questionnaires = useCalendarStore((state) => state.questionnaires);
 
   return (
     <S.Table>
@@ -103,12 +48,12 @@ function MainSheet() {
         </tr>
       </thead>
       <tbody>
-        {data?.questionnaires?.length ? (
-          data.questionnaires.map((item, idx) => (
+        {questionnaires.length ? (
+          questionnaires.map((item, idx) => (
             <tr key={item.serialNumber}>
               <S.Td><S.Count>{idx + 1}</S.Count></S.Td>
               <S.Td><S.Class />{item.userName}</S.Td>
-              <S.Td><S.Name/>{item.schoolNumber}</S.Td>
+              <S.Td><S.Name />{item.schoolNumber}</S.Td>
               <S.Td><S.Gender />{genderMap[item.gender] || item.gender}</S.Td>
               <S.Td><S.Division />{divisionMap[item.division] || item.division}</S.Td>
               <S.Td><S.Symptom />{item.disease}</S.Td>

--- a/app/components/subSheet.tsx
+++ b/app/components/subSheet.tsx
@@ -1,37 +1,26 @@
-import React, { useEffect, useState } from "react";
-import axios from "axios";
+import React from "react";
+import { useCalendarStore } from "@/store/useCalendarStore";
 
-// 카테고리 리스트
 const categories = [
   "호흡기계", "소화기계", "순환기계", "정신신경계", "근골격계", "피부피하계",
   "비뇨생식기계", "구강치아계", "이비인후과계", "안과계", "감염병", "상담", "기타", "계"
-];
+] as const;
 
 function SubSheet() {
-  const [data, setData] = useState<any>(null);
+  const statistics = useCalendarStore((state) => state.statistics);
 
-  useEffect(() => {
-    axios.get(`${process.env.NEXT_PUBLIC_REACT_APP_BASE_URL}/questionnaire/date`, {
-      headers: {
-        "Content-Type": "application/json",
-        'ngrok-skip-browser-warning': '69420',
-      }
-    })
-      .then((res) => {
-        console.log("전체 응답 데이터:", res.data);
-        setData(res.data.groupedStatistics);
-      })
-      .catch((err) => console.error("데이터 로딩 오류:", err));
-  }, []);
+  const renderCategoryRow = (
+    type: "일계" | "월계" | "누계",
+    gender: "남" | "여"
+  ) => {
+    
+  const rowData = statistics[type][gender];
 
-  // 카테고리별 데이터를 출력하는 함수
-  const renderCategoryRow = (type: string, gender: "남" | "여") => {
-    const rowData = data?.[type]?.[gender] || {};
-    return (
-      <>
-        <td className="border border-gray-300 p-2 bg-white">{gender}</td>
-        {categories.map((category, idx) => (
-          <td key={idx} className="border border-gray-300 p-2 bg-white">
+  return (
+    <>
+      <td className="border border-gray-300 p-2 bg-white">{gender}</td>
+        {categories.map((category) => (
+          <td key={category} className="border border-gray-300 p-2 bg-white">
             {rowData[category] ?? 0}
           </td>
         ))}
@@ -46,21 +35,33 @@ function SubSheet() {
           <tr className="bg-tableheader">
             <th className="border border-gray-300 p-2">종류</th>
             <th className="border border-gray-300 p-2">성별</th>
-            {categories.map((category, idx) => (
-              <th key={idx} className="border border-gray-300 p-2">{category}</th>
+            {categories.map((category) => (
+              <th key={category} className="border border-gray-300 p-2">
+                {category}
+              </th>
             ))}
           </tr>
         </thead>
         <tbody>
-          {["일계", "월계", "누계"].map((type, idx) => (
-            <React.Fragment key={idx}>
-              <tr>
-                <td className="border border-gray-300 p-2 bg-white" rowSpan={2}>{type}</td>
-                {renderCategoryRow(type, "남")}
-              </tr>
-              <tr>{renderCategoryRow(type, "여")}</tr>
-            </React.Fragment>
-          ))}
+          {statistics ? (
+            (["일계", "월계", "누계"] as const).map((type) => (
+              <React.Fragment key={type}>
+                <tr>
+                  <td className="border border-gray-300 p-2 bg-white" rowSpan={2}>
+                    {type}
+                  </td>
+                  {renderCategoryRow(type, "남")}
+                </tr>
+                <tr>{renderCategoryRow(type, "여")}</tr>
+              </React.Fragment>
+            ))
+          ) : (
+            <tr>
+              <td colSpan={16} className="p-4 text-center">
+                데이터 로딩 중...
+              </td>
+            </tr>
+          )}
         </tbody>
       </table>
     </div>

--- a/app/store/useCalendarStore.ts
+++ b/app/store/useCalendarStore.ts
@@ -1,0 +1,127 @@
+import { create } from 'zustand';
+import axios from 'axios';
+import { format } from 'date-fns';
+
+interface ApiResponse {
+  questionnaires: SheetData[];
+  groupedStatistics: {
+    누계: { 남: Record<string, number>; 여: Record<string, number> };
+    월계: { 남: Record<string, number>; 여: Record<string, number> };
+    일계: { 남: Record<string, number>; 여: Record<string, number> };
+  };
+}
+
+interface SheetState {
+  questionnaires: SheetData[];
+  dailyData: SheetData[];
+  currentData: SheetData[];
+  statistics: ApiResponse['groupedStatistics'];
+  selectedDate: Date | null;
+  fetchCurrentData: () => Promise<void>;
+  fetchDailyData: (date: Date) => Promise<void>;
+  setSelectedDate: (date: Date) => void;
+  mergeData: () => void;
+  initialize: () => Promise<void>;
+}
+
+export interface SheetData {
+  serialNumber: number;
+  userName: string;
+  schoolNumber: string;
+  gender: string;
+  division: string;
+  disease: string;
+  treatment: string;
+  quantity: number;
+  medication1: string;
+  quantity1: number;
+  medication2: string;
+  quantity2: number;
+  notes: string;
+}
+
+export const useCalendarStore = create<SheetState>((set, get) => ({
+  questionnaires: [],
+  dailyData: [],
+  currentData: [],
+  statistics: {
+    누계: { 남: {}, 여: {} },
+    월계: { 남: {}, 여: {} },
+    일계: { 남: {}, 여: {} }
+  },
+  selectedDate: null,
+
+  mergeData: () => {
+    const { dailyData, currentData } = get();
+    const uniqueData = [...new Map(
+      [...dailyData, ...currentData].map(item => [item.serialNumber, item])
+    ).values()];
+    set({ questionnaires: uniqueData });
+  },
+
+  fetchCurrentData: async () => {
+    try {      
+      const response = await axios.get<ApiResponse>(`${process.env.NEXT_PUBLIC_REACT_APP_BASE_URL}/questionnaire/date`, {
+        headers: {
+          'ngrok-skip-browser-warning': '69240',
+          'Content-Type': 'application/json'
+        }
+      });
+      
+      set({ 
+        currentData: response.data.questionnaires || [],
+        questionnaires: response.data.questionnaires || [],
+        statistics: response.data.groupedStatistics || {
+          누계: { 남: {}, 여: {} },
+          월계: { 남: {}, 여: {} },
+          일계: { 남: {}, 여: {} }
+        }
+      });
+    }
+    
+    catch (error) {
+      console.error('현재 데이터 조회 오류:', error);
+      set({ currentData: [] });
+    }
+  },
+
+  fetchDailyData: async (date) => {
+    try {
+      const yearMonthDayParam = format(date, 'yyyy.MM.dd');
+      const response = await axios.get<ApiResponse>(
+        `${process.env.NEXT_PUBLIC_REACT_APP_BASE_URL}/questionnaire/date?yearMonthDay=${yearMonthDayParam}`,
+        {
+          headers: {
+            'ngrok-skip-browser-warning': '69240',
+            'Content-Type': 'application/json'
+          }
+        }
+      );
+      
+      set({ 
+        dailyData: response.data.questionnaires || [],
+        questionnaires: response.data.questionnaires || [],
+        statistics: response.data.groupedStatistics || {
+          누계: { 남: {}, 여: {} },
+          월계: { 남: {}, 여: {} },
+          일계: { 남: {}, 여: {} }
+        }
+      });
+    }
+    
+    catch (error) {
+      console.error('일별 데이터 조회 오류:', error);
+      set({ dailyData: [] });
+    }
+  },
+
+  setSelectedDate: (date) => set({ selectedDate: date }),
+
+  initialize: async () => {
+    const today = new Date();
+    set({ selectedDate: today });
+    await get().fetchCurrentData();
+    await get().fetchDailyData(today);
+    get().mergeData();
+  },
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "react-icons": "^5.3.0",
         "react-quill": "^2.0.0",
         "styled-components": "^6.1.13",
-        "xlsx": "^0.18.5"
+        "xlsx": "^0.18.5",
+        "zustand": "^5.0.3"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",
@@ -6561,6 +6562,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react-icons": "^5.3.0",
     "react-quill": "^2.0.0",
     "styled-components": "^6.1.13",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",


### PR DESCRIPTION
## 문제 상황
문진표 페이지의 메인 보드와 서브보드의 데이터 표시가 실시간 표시가 되지 않아 새로고침을 해야 데이터가 표시되는 문제가 있었다.
그렇지만 더 큰 문제는 새로고침 시 캘린더 컴포넌트의 날짜 선택이 풀리기 때문에 현재가 아닌
다른 날짜의 데이터 표시가 안되는 버그가 발생함.

## 해결 과정
실시간 표시 기능은 이번 문진표 뿐만이 아니라 프로젝트 특성 상, 실시간 표시할 데이터들이 많아
재사용성이 좋은 방식이 필요하다고 생각했었음.

또한 대부분의 데이터를 객체로 받기 때문에 interface를 컴포넌트 마다 type을 선언하며 사용한 방식을 interface를 제공하는 다른 파일을 만들어 import 해오는 방식이 더 효율적이라고 생각함.

마지막으로 문진표 페이지 경우 대부분의 로직이 캘린더와 연동이 되기 때문에 캘린더에 사용되는 api 또한 캘린더 컴포넌트에 넣는 것이 아닌 대체 파일을 만들고 그 파일을 import 하는 방식으로 사용하면 재사용성이 높아질 것이라고 판단함

## 해결 방식
zustand를 추가하여 store를 이용하여, 캘린더 컴포넌트의 axios 코드를 store에 옮겨,
받은 문진표 데이터를 interface에 저장하여, mainSheet, subSheet 컴포넌트에서 store를 import하여 사용하는 형식으로 바꾸었다.