### PR TITLE
bugfix: 약 관리 페이지 리스트 관련 전체 실시간 표시화

### DIFF
--- a/app/organisms/MediList.tsx
+++ b/app/organisms/MediList.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { FaTrashAlt, FaPen } from 'react-icons/fa';
 import axios from 'axios';
+import useMedicalStore from '@/store/useMedicalStore';
 
 interface Medicine {
   id: number;
@@ -97,32 +98,7 @@ const ActionTd = styled.td`
 `;
 
 const MedicineTable: React.FC<MedicineTableProps> = ({ onAdd, onEdit }) => {
-  const [medicines, setMedicines] = useState<Medicine[]>([]);
-
-  const fetchMedicines = () => {
-    axios
-      .get(`${process.env.NEXT_PUBLIC_REACT_APP_BASE_URL}/medicine/get`, {
-        headers: {
-          'Content-Type': 'application/json',
-          'ngrok-skip-browser-warning': '69420',
-        },
-      })
-      .then((res) => {
-        const data = res.data;
-        if (Array.isArray(data)) {
-          setMedicines(data);
-        } else {
-          console.error('🚨 예상과 다르게 배열이 아님:', data);
-        }
-      })
-      .catch((err) => {
-        console.error('약 정보를 불러오는 데 실패했습니다.', err);
-      });
-  };
-
-  useEffect(() => {
-    fetchMedicines();
-  }, []);
+  const { medicines, fetchMedicines } = useMedicalStore();
 
   const handleDelete = async (id: number, name: string) => {
     const confirmDelete = confirm(`정말로 "${name}" 약을 삭제하시겠습니까?`);
@@ -136,12 +112,17 @@ const MedicineTable: React.FC<MedicineTableProps> = ({ onAdd, onEdit }) => {
         },
       });
   
-      setMedicines((prev) => prev.filter((med) => med.id !== id));
+      // 삭제 후 자동으로 최신 데이터 가져옴
+      fetchMedicines();
       console.log(`🗑️ ${name} 삭제 성공`);
     } catch (error) {
       console.error(`❌ ${name} 삭제 실패`, error);
     }
-  };  
+  }; 
+
+  React.useEffect(() => {
+    fetchMedicines();
+  }, [fetchMedicines]);
 
   return (
     <Container>

--- a/app/organisms/MediModal.tsx
+++ b/app/organisms/MediModal.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import axios from 'axios';
+import useMedicalStore from '@/store/useMedicalStore';
 
 interface DrugModalProps {
   onClose: () => void;
@@ -64,14 +65,7 @@ export default function DrugModal({ onClose, initialData }: DrugModalProps) {
   const [name, setName] = useState('');
   const [category, setCategory] = useState('정제');
   const [quantity, setQuantity] = useState('');
-
-  useEffect(() => {
-    if (initialData) {
-      setName(initialData.name);
-      setCategory(initialData.type);
-      setQuantity(initialData.count !== undefined ? `${initialData.count}개` : '');
-    }
-  }, [initialData]);
+  const { addMedicine, updateMedicine } = useMedicalStore();
 
   const handleSubmit = async () => {
     if (!name || !category || !quantity) {
@@ -79,32 +73,37 @@ export default function DrugModal({ onClose, initialData }: DrugModalProps) {
       return;
     }
   
-    const newData = {
-      medicineName: name,
-      medicineType: category,
-      medicineCount: quantity,
-    };
+    const parsedQuantity = parseInt(quantity);
+    if (isNaN(parsedQuantity)) {
+      alert('유효한 수량을 입력해주세요.');
+      return;
+    }
   
     try {
       if (initialData) {
-        // PUT: 수정 (medicineId 포함)
-        await axios.put(`${process.env.NEXT_PUBLIC_REACT_APP_BASE_URL}/medicine/update`, {
-          medicineId: initialData.id,
-          ...newData,
+        // 수정 로직
+        if (!initialData?.id) throw new Error('Invalid ID');
+        await updateMedicine({
+          id: initialData.id, // ✅ number
+          name,
+          type: category,
+          count: parsedQuantity,
+          body_system: null
         });
-        console.log('수정 완료:', { medicineId: initialData.id, ...newData });
       } else {
-        // POST: 등록
-        await axios.post(`${process.env.NEXT_PUBLIC_REACT_APP_BASE_URL}/medicine/insert`, newData);
-        console.log('등록 완료:', newData);
+        // 생성 로직 (ID 없이 전송)
+        await addMedicine({
+          name,
+          type: category,
+          count: parsedQuantity,
+          body_system: null
+        });
       }
       onClose();
     } catch (error) {
-      console.error('에러 발생:', error);
-      alert('요청 중 문제가 발생했습니다.');
+      alert('처리 중 오류가 발생했습니다');
     }
-  };
-  
+  };  
 
   return (
     <Overlay>

--- a/app/pages/Main.tsx
+++ b/app/pages/Main.tsx
@@ -153,7 +153,7 @@ function Main() {
                   </span>
                 </div>
               )}
-              <div className="w-[18.66331rem] h-[18rem] flex mt-[1rem] overflow-scroll scrollbar-hide">
+              <div className="w-full h-[18rem] flex gap-[1rem] mt-[1rem] overflow-scroll scrollbar-hide">
                 {rentDataList.map(({ id, ...visit }) => (
                   <RentData key={id} {...visit} />
                 ))}

--- a/app/pages/MediMangament.tsx
+++ b/app/pages/MediMangament.tsx
@@ -20,17 +20,19 @@ export default function DrugManagementPage() {
   return (
     <>
       <Nav />
-      <MedicineTable
-        onAdd={() => setIsAddOpen(true)}
-        onEdit={(data) => setEditData(data)}
-      />
-      {isAddOpen && <DrugModal onClose={() => setIsAddOpen(false)} />}
-      {editData && (
-        <DrugModal
-          initialData={editData}
-          onClose={() => setEditData(null)}
+      <div className='w-full h-full overflow-scroll scrollbar-hide'>
+        <MedicineTable
+          onAdd={() => setIsAddOpen(true)}
+          onEdit={(data) => setEditData(data)}
         />
-      )}
+        {isAddOpen && <DrugModal onClose={() => setIsAddOpen(false)} />}
+        {editData && (
+          <DrugModal
+            initialData={editData}
+            onClose={() => setEditData(null)}
+          />
+        )}
+      </div>
     </>
   );
 }

--- a/app/store/useMedicalStore.ts
+++ b/app/store/useMedicalStore.ts
@@ -1,0 +1,108 @@
+import { create } from 'zustand';
+import axios from 'axios';
+
+interface Medicine {
+  id: number;
+  name: string;
+  count: number;
+  body_system: string | null;
+  type: string;
+}
+
+type NewMedicine = Omit<Medicine, 'id'>;
+
+interface MedicalStore {
+    medicines: Medicine[];
+    fetchMedicines: () => Promise<void>;
+    addMedicine: (newMedicine: NewMedicine) => Promise<void>;
+    updateMedicine: (updatedMedicine: Medicine) => Promise<void>;
+  }
+
+const useMedicalStore = create<MedicalStore>((set) => ({
+  medicines: [],
+
+  fetchMedicines: async () => {
+    try {
+      const res = await axios.get(`${process.env.NEXT_PUBLIC_REACT_APP_BASE_URL}/medicine/get`, {
+        headers: {
+          'Content-Type': 'application/json',
+          'ngrok-skip-browser-warning': '69420',
+        },
+      });
+      set({ medicines: Array.isArray(res.data) ? res.data : [] });
+    } catch (err) {
+      console.error('약 정보 불러오기 실패', err);
+      set({ medicines: [] });
+    }
+  },
+
+  // 추가된 메서드들
+  addMedicine: async (newMedicine) => {
+    const tempId = Date.now();
+  
+    // 1. 낙관적 업데이트
+    set((state) => ({
+      medicines: [{ ...newMedicine, id: tempId }, ...state.medicines]
+    }));
+  
+    try {
+      // 2. API 요청 (URL 추가)
+      const res = await axios.post<Medicine>(
+        `${process.env.NEXT_PUBLIC_REACT_APP_BASE_URL}/medicine/insert`,
+        {
+          medicineName: newMedicine.name,
+          medicineType: newMedicine.type,
+          medicineCount: newMedicine.count
+        },
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            'ngrok-skip-browser-warning': '69420'
+          }
+        }
+      );
+  
+      // 3. 실제 ID로 교체
+      set((state) => ({
+        medicines: state.medicines.map(med => 
+          med.id === tempId ? res.data : med
+        )
+      }));
+    } catch (err) {
+      // 4. 롤백
+      set((state) => ({
+        medicines: state.medicines.filter(med => med.id !== tempId)
+      }));
+      throw err;
+    }
+  },  
+
+  updateMedicine: async (updatedMedicine) => {
+    set((state) => ({
+      medicines: state.medicines.map(med =>
+        med.id === updatedMedicine.id ? updatedMedicine : med
+      )
+    }));
+
+    try {
+      await axios.put(
+        `${process.env.NEXT_PUBLIC_REACT_APP_BASE_URL}/medicine/update`,
+        {
+          medicineId: updatedMedicine.id,
+          medicineName: updatedMedicine.name,
+          medicineType: updatedMedicine.type,
+          medicineCount: updatedMedicine.count
+        }
+      );
+    } catch (err) {
+      set((state) => ({
+        medicines: state.medicines.map(med =>
+          med.id === updatedMedicine.id ? med : med
+        )
+      }));
+      throw err;
+    }
+  }
+}));
+
+export default useMedicalStore;


### PR DESCRIPTION
기존 약 관리 페이지의 약 관리 테이블은 실시간 표시가 아니였음
약 관리 페이지에서 약을 추가 시에 약이 바로 최신순으로 정렬이 안되고, 새로고침을 해야만 최신순 정렬이 되었음