### PR TITLE
bugfix: 5가지 버그 개선

### DIFF
--- a/app/molecules/RentDataAdmin.tsx
+++ b/app/molecules/RentDataAdmin.tsx
@@ -17,9 +17,11 @@ function RentDataAdmin({ rentalId, count, formattedDate, rental, rentaled, name 
 
     const handleReturn = async () => {
         try {
-            await axios.put(`${process.env.NEXT_PUBLIC_REACT_APP_BASE_URL}/rental/${rentalId}`);
+            const response = await axios.put(`${process.env.NEXT_PUBLIC_REACT_APP_BASE_URL}/rental/${rentalId}`);
             setIsReturned(true);
-        } catch (error) {
+        }
+        
+        catch (error) {
             console.error(error);
             alert("반납 요청 중 오류가 발생했습니다.");
         }

--- a/app/molecules/Usercard.tsx
+++ b/app/molecules/Usercard.tsx
@@ -19,6 +19,11 @@ export function Usercard({ name, gender, schoolNumber }: UsercardProps) {
     const [healthData, setHealthData] = useState<HealthIssues | null>(null);
 
     const handleClick = async () => {
+        if (isExpanded) {
+            // If already open, just close it
+            setIsExpanded(false);
+            return;
+        }
         try {
             const res = await axios.post(
                 `${process.env.NEXT_PUBLIC_REACT_APP_BASE_URL}/user/healthissues/${schoolNumber}`
@@ -29,7 +34,8 @@ export function Usercard({ name, gender, schoolNumber }: UsercardProps) {
             console.error("특이사항 요청 실패:", err);
             alert("특이사항을 불러오지 못했습니다.");
         }
-    };  
+    };
+
 
     const renderHealthItem = (label: string, value?: string) => {
         if (!value) return null;
@@ -60,7 +66,7 @@ export function Usercard({ name, gender, schoolNumber }: UsercardProps) {
                     className="h-[2rem] font-[pretendard] border rounded-[0.5rem] border-[#98A2B3] inline-flex text-[1.25rem] px-[5.94rem] py-[0.5rem] justify-center items-center"
                     onClick={handleClick}
                 >
-                    학생 특이사항 확인
+                    {isExpanded ? "학생 특이사항 닫기" : "학생 특이사항 확인"}
                 </button>
             </div>
 

--- a/app/organisms/MediList.tsx
+++ b/app/organisms/MediList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { FaTrashAlt, FaPen } from 'react-icons/fa';
 import axios from 'axios';
@@ -97,6 +97,20 @@ const ActionTd = styled.td`
   }
 `;
 
+// 컴포넌트 상단에 추가
+const getTypeLabel = (type: any) => {
+  switch (type) {
+    case 'GENERAL_MEDICINE':
+      return '일반약';
+    case 'COLD_MEDICINE':
+      return '감기약';
+    case 'PAINKILLER':
+      return '진통제';
+    default:
+      return type; // 혹시 모르는 타입은 그대로 출력
+  }
+};
+
 const MedicineTable: React.FC<MedicineTableProps> = ({ onAdd, onEdit }) => {
   const { medicines, fetchMedicines } = useMedicalStore();
 
@@ -142,7 +156,7 @@ const MedicineTable: React.FC<MedicineTableProps> = ({ onAdd, onEdit }) => {
             {medicines.map((item) => (
               <tr key={item.id}>
                 <Td>{item.name}</Td>
-                <Td>{item.type}</Td>
+                <Td>{getTypeLabel(item.type)}</Td>
                 <Td style={{ fontWeight: 'bold' }}>{item.count}</Td>
                 <ActionTd>
                   <FaPen onClick={() => onEdit(item)} />

--- a/app/organisms/MediModal.tsx
+++ b/app/organisms/MediModal.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import axios from 'axios';
 import useMedicalStore from '@/store/useMedicalStore';
 
 interface DrugModalProps {
@@ -84,7 +83,7 @@ export default function DrugModal({ onClose, initialData }: DrugModalProps) {
         // 수정 로직
         if (!initialData?.id) throw new Error('Invalid ID');
         await updateMedicine({
-          id: initialData.id, // ✅ number
+          id: initialData.id,
           name,
           type: category,
           count: parsedQuantity,
@@ -117,9 +116,9 @@ export default function DrugModal({ onClose, initialData }: DrugModalProps) {
           value={category}
           onChange={(e) => setCategory(e.target.value)}
         >
-          <option value="일반약">일반약</option>
-          <option value="감기약">감기약</option>
-          <option value="진통제">진통제</option>
+          <option value="GENERAL_MEDICINE">일반약</option>
+          <option value="COLD_MEDICINE">감기약</option>
+          <option value="PAINKILLER">진통제</option>
         </Select>
         <Input
           placeholder="용량"

--- a/app/styles/RentDataAdmin.ts
+++ b/app/styles/RentDataAdmin.ts
@@ -171,7 +171,7 @@ export const student = styled.span`
 
 export const StudentName = styled.span`
     position: absolute;
-    width: 42px;
+    width: 62px;
     height: 19px;
     top: 16px;
 


### PR DESCRIPTION
## 약 관리 페이지 쪽 버그 픽스
1. 약의 타입이 key값이 아닌 value값으로 표시가 되고 있던 오류 개선
2. 약 수정 시 api로 값을 보낼 때 value 값이 아닌 key 값을 보내던 오류 개선
3. 약 타임에 대한 관리가 이상하게 되던 오류 개선, key : value 방식의 관리법으로 변경

## 대여기록 컴포넌트 버그 픽스
- 3글자 이상 학생의 이름이 표시되는 ui 오류 개선, 최대 5글자까지 정상으로 표시되게 변경

## 학생 데이터 명렬 페이지
- 학생 특이사항 보기 버튼을 누른 뒤 닫기 버튼이 정상 작동하지 않았던 오류 개선