### PR TITLE
bugfix: method

### DIFF
--- a/app/API/DustAPI.ts
+++ b/app/API/DustAPI.ts
@@ -3,7 +3,7 @@ const DEBOUNCE_DELAY = 2000;
 
 export async function getDustData(sidoName: string): Promise<any> {
     const DUST_API_KEY = process.env.NEXT_PUBLIC_DAWA_WEATHER_API_KEY;
-    const url = 'http://apis.data.go.kr/B552584/ArpltnInforInqireSvc/getCtprvnRltmMesureDnsty';
+    const url = 'https://apis.data.go.kr/B552584/ArpltnInforInqireSvc/getCtprvnRltmMesureDnsty';
 
     const params = {
         serviceKey: DUST_API_KEY,

--- a/app/API/dust.ts
+++ b/app/API/dust.ts
@@ -4,7 +4,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const { sidoName } = req.query;
     const apiKey = process.env.NEXT_PUBLIC_DAWA_WEATHER_API_KEY;
 
-    const url = `http://apis.data.go.kr/B552584/ArpltnInforInqireSvc/getCtprvnRltmMesureDnsty?serviceKey=${apiKey}&sidoName=${sidoName}&pageNo=1&numOfRows=100&dataTerm=DAILY&ver=1.3&returnType=JSON`;
+    const url = `https://apis.data.go.kr/B552584/ArpltnInforInqireSvc/getCtprvnRltmMesureDnsty?serviceKey=${apiKey}&sidoName=${sidoName}&pageNo=1&numOfRows=100&dataTerm=DAILY&ver=1.3&returnType=JSON`;
 
     try {
         const response = await fetch(url);


### PR DESCRIPTION
dust.ts와 DustApi.ts에 사용되는 기상청 미세먼지 관련 api 링크가 http를 사용하여 mixed content 에러가 걸림
=>
https로 변환해봄